### PR TITLE
Update fixer for TS#56571 to remove all References

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import assert from 'node:assert';
 
-import { fixEmberReferences } from './fixes/ember.js';
 import * as glint from './fixes/glint.js';
+import * as ts from './fixes/typescript.js';
 import { fixFile, getFiles } from './utils.js';
 
 const [, , ...args] = process.argv;
@@ -13,7 +13,7 @@ assert(typeof pattern === 'string', 'Please pass a glob pattern to `fix-bad-decl
 for (let filePath of await getFiles(pattern)) {
   await fixFile(filePath, [
     // e.g.: /// <reference types="ember
-    fixEmberReferences,
+    ts.fixReferences,
     // e.g.: import './foo.gts'
     glint.fixGTSExtensions,
     // e.g.: /// <reference type="node_modules/@glint

--- a/src/fixes/index.js
+++ b/src/fixes/index.js
@@ -1,11 +1,11 @@
-import { fixEmberReferences } from './ember.js';
 import * as glint from './glint.js';
+import { fixReferences } from './typescript.js';
 
 export const issues = {
   /**
    * https://github.com/microsoft/TypeScript/issues/56571#issuecomment-1830436576
    */
-  'TypeScript#56571': fixEmberReferences,
+  'TypeScript#56571': fixReferences,
   /**
    * https://github.com/typed-ember/glint/issues/628
    */

--- a/src/fixes/typescript.js
+++ b/src/fixes/typescript.js
@@ -2,18 +2,14 @@ import jscodeshift from 'jscodeshift';
 
 const j = jscodeshift.withParser('ts');
 
-const defaultFind = 'ember';
-
 /**
  * @param {string} contents
  * @param {{ types?: string | 'all' }} [ options ]
  */
 export function fixReferences(contents, options = {}) {
   const root = j(contents);
-  const find =
-    options.types === 'all'
-      ? `/ <reference types=`
-      : `/ <reference types="${options.types || defaultFind}`;
+  const removeAll = !options.types || options.types === 'all';
+  const find = removeAll ? `/ <reference types=` : `/ <reference types="${options.types}`;
 
   const fixed = root
     // @ts-expect-error

--- a/src/fixes/typescript.test.ts
+++ b/src/fixes/typescript.test.ts
@@ -6,9 +6,11 @@ import { fixReferences } from './typescript.js';
 const expect = hardAssert.soft;
 
 describe('fixReferences', () => {
-  test('defaults: match ember-source', () => {
+  test('defaults: match everything', () => {
     let code = stripIndent`
-      /// <reference types="ember-source/whatever/module">"
+      /// <reference types="ember-source/whatever/module">
+      /// <reference types="everything">
+      /// <reference types="another">
       export const two = 2;`;
 
     let result = fixReferences(code);
@@ -18,9 +20,9 @@ describe('fixReferences', () => {
 
   test('defaults: match multiple ember-source', () => {
     let code = stripIndent`
-      /// <reference types="ember-source/whatever/module">"
-      /// <reference types="ember-source/whatever1/module">"
-      /// <reference types="ember-source/whatever2/module">"
+      /// <reference types="ember-source/whatever/module">
+      /// <reference types="ember-source/whatever1/module">
+      /// <reference types="ember-source/whatever2/module">
       export const two = 2;`;
 
     let result = fixReferences(code);
@@ -28,19 +30,9 @@ describe('fixReferences', () => {
     expect(result).toBe(`export const two = 2;`);
   });
 
-  test('defaults: ignore non-specified', () => {
-    let code = stripIndent`
-      /// <reference types="not-ember-source/whatever/module">"
-      export const two = 2;`;
-
-    let result = fixReferences(code);
-
-    expect(result).toBe(code);
-  });
-
   test('custom: works', () => {
     let code = stripIndent`
-      /// <reference types="@glint/whatever/module">"
+      /// <reference types="@glint/whatever/module">
       export const two = 2;`;
 
     let result = fixReferences(code, { types: '@glint' });
@@ -50,9 +42,9 @@ describe('fixReferences', () => {
 
   test('custom: removes multiple', () => {
     let code = stripIndent`
-      /// <reference types="@glint/whatever/module">"
-      /// <reference types="@glint/whatever2/module">"
-      /// <reference types="@glint/whatever5/module">"
+      /// <reference types="@glint/whatever/module">
+      /// <reference types="@glint/whatever2/module">
+      /// <reference types="@glint/whatever5/module">
       export const two = 2;`;
 
     let result = fixReferences(code, { types: '@glint' });
@@ -62,14 +54,14 @@ describe('fixReferences', () => {
 
   test('custom: does not remove more than what is specified', () => {
     let code = stripIndent`
-      /// <reference types="@glint/whatever/module">"
-      /// <reference types="node_modules/@glint/whatever2/module">"
+      /// <reference types="@glint/whatever/module"
+      /// <reference types="node_modules/@glint/whatever2/module">
       export const two = 2;`;
 
     let result = fixReferences(code, { types: '@glint' });
 
     expect(result).toBe(stripIndent`
-      /// <reference types="node_modules/@glint/whatever2/module">"
+      /// <reference types="node_modules/@glint/whatever2/module">
       export const two = 2;`);
   });
 


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/issues/56571#issuecomment-1830436576

I'm increasingly starting to believe `/// <reference` is not the correct approach.

You
- move types to `dependencies`
- or declare a `peerDependencies` entry on the types
  and your consumer provides the types (this is the Scenario the TS team has been hesitant to support) 
